### PR TITLE
fix(rights): #CO-1595 fix correct assignation right's binding to booking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,4 @@ node:
   volumes:
     - ./:/home/node/app
     - ~/.npm:/.npm
-
+    - ~/.npmrc:/home/node/.npmrc

--- a/src/main/resources/public/ts/behaviours.ts
+++ b/src/main/resources/public/ts/behaviours.ts
@@ -33,7 +33,7 @@ Behaviours.register('rbs', {
         if (resource instanceof Resource && resource.type) {
             rightsContainer = resource.type;
         }
-        if (resource instanceof Booking && resource.resource && resource.resource.type) {
+        if ((resource && (resource instanceof Booking || resource.isBookingInstance)) && resource.resource && resource.resource.type) {
             rightsContainer = resource.resource.type;
         }
 

--- a/src/main/resources/public/ts/controller.ts
+++ b/src/main/resources/public/ts/controller.ts
@@ -1,6 +1,7 @@
-import {_, angular, idiom as lang, ng, notify, routes, template} from 'entcore';
+import {_, angular, Behaviours, idiom as lang, ng, notify, routes, template} from 'entcore';
 import moment from './moment';
 import {isBookingSlot, RBS} from './models';
+import {BookingUtil} from "./utilities/booking";
 
 
 const {Booking, ExportBooking, Notification, Resource, ResourceType, Slot, SlotJson, SlotProfile} = RBS;
@@ -792,6 +793,7 @@ export const RbsController: any = ng.controller('RbsController', ['$scope', 'rou
         };
 
         $scope.switchSelectAllSlots = function (booking) {
+            BookingUtil.setRightsResourceBooking(booking);
             if (booking.is_periodic === true && booking.selected === true) {
                 _.each(booking._slots, function (slot) {
                     slot.selected = true;

--- a/src/main/resources/public/ts/models.ts
+++ b/src/main/resources/public/ts/models.ts
@@ -1,5 +1,6 @@
 import {_, angular, Behaviours, http, Model, notify} from 'entcore';
 import moment from './moment';
+import {BookingUtil} from "./utilities/booking";
 
 declare let window: any;
 declare let model: any;
@@ -967,6 +968,7 @@ model.build = function () {
             if (startDate) {
                 http().get('/rbs/bookings/all/' + startDate.format('YYYY-MM-DD') +
                     '/' + endDate.format('YYYY-MM-DD')).done(function (bookings) {
+                    BookingUtil.setTagBookingInstance(bookings);
                     this.load(bookings);
                     mapObject(this);
                     if (typeof callback === 'function') {
@@ -978,6 +980,7 @@ model.build = function () {
             } else {
                 http().get('/rbs/bookings/all/' + model.bookings.startPagingDate.format('YYYY-MM-DD') +
                     '/' + model.bookings.endPagingDate.format('YYYY-MM-DD')).done(function (bookings) {
+                    BookingUtil.setTagBookingInstance(bookings);
                     this.load(bookings);
                     mapObject(this);
                     if (typeof callback === 'function') {
@@ -991,6 +994,7 @@ model.build = function () {
         syncForShowList: function (callback) {
             const collection = this;
             http().get('/rbs/bookings/all').done(function (bookings) {
+                BookingUtil.setTagBookingInstance(bookings);
                 this.load(bookings);
                 mapObject(this);
                 if (typeof callback === 'function') {

--- a/src/main/resources/public/ts/utilities/booking.ts
+++ b/src/main/resources/public/ts/utilities/booking.ts
@@ -1,0 +1,22 @@
+import {_, Behaviours} from "entcore";
+
+export class BookingUtil {
+
+    /**
+     * Method that update/set `myRights` resource if data booking is not updated properly
+     * @param booking Booking
+     */
+    static setRightsResourceBooking(booking: any): void {
+        if (booking && booking.myRights && _.isEmpty(booking.myRights)) {
+            Behaviours.applicationsBehaviours.rbs.resourceRights(booking);
+        }
+    }
+
+    /**
+     * Method that certified this item is a 'Booking' type data
+     * @param bookings Array<Bookings> (Supposedly)
+     */
+    static setTagBookingInstance(bookings: any): void {
+        bookings.forEach(b => b.isBookingInstance = true);
+    }
+}


### PR DESCRIPTION
Actuellement dans le calendrier chaque item dans un créneau ne voit pas apparaître un checkbox pour gérer cette donnée : 

![bugrbs_1](https://user-images.githubusercontent.com/10532050/133976818-b1b3de1c-b320-47fa-9846-6eb035fd3ee9.PNG)

la raison est due au fait que le champ `myRights` ne soit pas assigné à des droits avec la méthode `resourceRights` du behaviour.

En corrigeant le binding, on permet au right pour le `Booking` d'être correctement assigné au moment de la récupération :  

![rbsbug2](https://user-images.githubusercontent.com/10532050/133977473-b633b4d5-6e6a-4b48-a572-c22cfada209f.PNG)

