### PR TITLE
fix(sniplet): #RBS-122 move min max delay warning

### DIFF
--- a/src/main/resources/public/template/behaviours/sniplet-calendar-rbs-booking.html
+++ b/src/main/resources/public/template/behaviours/sniplet-calendar-rbs-booking.html
@@ -12,16 +12,6 @@
         <div ng-if="vm.recurrenceOrMultidaysAdded()" class="info">
             <i18n>rbs.calendar.sniplet.recurrence.multiday.edition.warning</i18n>
         </div>
-        <!-- Min delay not respected warning -->
-        <div ng-if="vm.resourceHasMinDelay() && !vm.checkMinDelay()" class="info">
-            <i18n>rbs.calendar.sniplet.min.delay.not.respected</i18n> [[vm.displayDelayDays(vm.editedBooking.resource.minDelay)]]
-            <i18n>rbs.calendar.sniplet.days.in.advance</i18n>
-        </div>
-        <!-- Max delay not respected warning -->
-        <div ng-if="vm.resourceHasMaxDelay() && !vm.checkMaxDelay()" class="info">
-            <i18n>rbs.calendar.sniplet.max.delay.not.respected</i18n> [[vm.displayDelayDays(vm.editedBooking.resource.maxDelay)]]
-            <i18n>rbs.calendar.sniplet.days.in.advance</i18n>
-        </div>
         <div class="content" ng-if="!vm.calendarEventIsBeforeToday() || vm.canViewBooking">
             <!-- Booking checkbox -->
             <div class="row" ng-show="vm.hasBookingRight && !vm.calendarEvent._id">
@@ -63,6 +53,17 @@
                     <!-- Warning : booking quantity problem -->
                     <div ng-if="!vm.isResourceQuantityAllowingBooking() && vm.isBookingPossible(true)" class="info">
                         <i18n>rbs.booking.edit.quantity.null</i18n>
+                    </div>
+
+                    <!-- Min delay not respected warning -->
+                    <div ng-if="vm.resourceHasMinDelay() && !vm.checkMinDelay()" class="info">
+                        <i18n>rbs.calendar.sniplet.min.delay.not.respected</i18n> [[vm.displayDelayDays(vm.editedBooking.resource.minDelay)]]
+                        <i18n>rbs.calendar.sniplet.days.in.advance</i18n>
+                    </div>
+                    <!-- Max delay not respected warning -->
+                    <div ng-if="vm.resourceHasMaxDelay() && !vm.checkMaxDelay()" class="info">
+                        <i18n>rbs.calendar.sniplet.max.delay.not.respected</i18n> [[vm.displayDelayDays(vm.editedBooking.resource.maxDelay)]]
+                        <i18n>rbs.calendar.sniplet.days.in.advance</i18n>
                     </div>
                     <div class="row accordions">
                         <!-- Resource description -->

--- a/src/main/resources/public/ts/sniplets/calendar-rbs-booking.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/calendar-rbs-booking.sniplet.ts
@@ -63,6 +63,8 @@ interface IViewModel {
 
     userIsAdml(): boolean;
 
+    userIsSuperAdmin(): boolean;
+
     prepareBookingStartAndEnd(booking?: Booking): void;
 
     availableResourceQuantity(): number;
@@ -375,6 +377,13 @@ class ViewModel implements IViewModel {
     }
 
     /**
+     * Returns true if the user is Super Admin
+     */
+    userIsSuperAdmin(): boolean {
+        return model.me.functions.SUPER_ADMIN;
+    }
+
+    /**
      * Returns true if the event takes place in the past
      */
     calendarEventIsBeforeToday(): boolean {
@@ -522,14 +531,20 @@ class ViewModel implements IViewModel {
      * Returns true if the minimum delay is compliant
      */
     checkMinDelay(): boolean {
-        return BookingDelayUtil.checkMinDelay(this.editedBooking);
+        let delaybooking: Booking = angular.copy(this.editedBooking);
+        this.prepareBookingStartAndEnd(delaybooking);
+
+        return (BookingDelayUtil.checkMinDelay(delaybooking) || this.userIsAdml() || this.userIsSuperAdmin());
     }
 
     /**
      * Returns true if the maximum delay is compliant
      */
     checkMaxDelay(): boolean {
-       return BookingDelayUtil.checkMaxDelay(this.editedBooking);
+        let delaybooking: Booking = angular.copy(this.editedBooking);
+        this.prepareBookingStartAndEnd(delaybooking);
+
+       return (BookingDelayUtil.checkMaxDelay(delaybooking) || this.userIsAdml() || this.userIsSuperAdmin());
     }
 
     /**


### PR DESCRIPTION
## Describe your changes
fixes following the testing of RBS-122:
- ADML user can book without regard of the delays
- days are counted as full
- fix timezone problem

## Checklist tests
with adml or super admin account: try to create a booking outside the delay boudaries
with normal account: test the delay boundaries (eg if the boundary is 16:00 try to have a start date at 15:59 or 16:01)

## Issue ticket number and link
RBS-122 fix https://entsupport.gdapublic.fr/browse/RBS-122

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

