### PR TITLE
fix(access): #RBS-127 restrict super admin access to sniplet if no access to rbs

### DIFF
--- a/src/main/resources/public/template/behaviours/sniplet-calendar-rbs-booking.html
+++ b/src/main/resources/public/template/behaviours/sniplet-calendar-rbs-booking.html
@@ -1,5 +1,5 @@
 <article id="calendar-booking" class="sniplet rbs calendarBooking"
-         ng-if="(vm.hasBookingRight && !vm.calendarEvent._id) || vm.canViewBooking">
+         ng-if="(vm.hasRbsAccess() && (vm.hasBookingRight && !vm.calendarEvent._id) || vm.canViewBooking)">
     <h2 class="backgroundBlueTitle" ng-if="vm.canEditEvent">
         <i18n>rbs.title</i18n>
     </h2>


### PR DESCRIPTION
## Describe your changes
if super admin has no access to rbs the sniplet does not appeat

## Checklist tests
find super admin (central admin) account, delete RBS access from all their structures, open the event creation form and check if the sniplet appears

## Issue ticket number and link
RBS-127 https://entsupport.gdapublic.fr/browse/RBS-127

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

