### PR TITLE
fix(calendar): #RBS-168 add display option to persist preference display

### DIFF
--- a/src/main/resources/public/template/main-calendar.html
+++ b/src/main/resources/public/template/main-calendar.html
@@ -24,6 +24,8 @@
             display-month-template="calendar/display-calendar-month-item"
             more-items-template="calendar/display-calendar-more-items"
             item-tooltip-template="calendar/tooltip-template"
+            display-options="true"
+            show-next-previous-button="true"
             items="bookings.filtered">
     </calendar>
 </div>
@@ -35,6 +37,8 @@
             display-month-template="calendar/display-calendar-month-item"
             more-items-template="calendar/display-calendar-more-items"
             item-tooltip-template="calendar/tooltip-template"
+            display-options="true"
+            show-next-previous-button="true"
             items="bookings.filtered">
     </calendar>
 </div>


### PR DESCRIPTION
## Describe your changes

Ajout props dans le composant calendar pour déclencher l'activation des préférences pour faire persister le calendrier pour samedi/dimanche

## Checklist tests

Depuis l'application RBS, on devrait avoir un appel "calendarOptions" dans les préférences (voir console network) qui doit se déclencher et faire persister "samedi" et/ou "dimanche".

Activer/désactiver l'option samedi/dimanche et réactualiser => le calendrier doit s'adapter en fonction de l'affichage et des préférences

## Issue ticket number and link

https://jira.support-ent.fr/browse/RBS-168

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

